### PR TITLE
Refactor Kanban view to utilize a new count property in badge component

### DIFF
--- a/app/manage-projects/[projectSlug]/contributions/_features/kanban-view/kanban-view.tsx
+++ b/app/manage-projects/[projectSlug]/contributions/_features/kanban-view/kanban-view.tsx
@@ -63,7 +63,8 @@ function Column({
     }
   }, [type]);
 
-  const count = data?.pages?.[0]?.totalItemNumber ?? 0;
+  const count = useMemo(() => data?.pages?.[0]?.totalItemNumber ?? 0, [data]);
+
   return (
     <KanbanColumn
       {...kanbanProps}

--- a/app/manage-projects/[projectSlug]/contributions/_features/kanban-view/kanban-view.tsx
+++ b/app/manage-projects/[projectSlug]/contributions/_features/kanban-view/kanban-view.tsx
@@ -63,6 +63,7 @@ function Column({
     }
   }, [type]);
 
+  const count = data?.pages?.[0]?.totalItemNumber ?? 0;
   return (
     <KanbanColumn
       {...kanbanProps}
@@ -71,7 +72,7 @@ function Column({
       isFetchingNextPage={isFetchingNextPage}
       header={{
         title,
-        badge: { children: data?.pages?.[0]?.totalItemNumber ?? "0" },
+        badge: { children: count, count },
         ...(kanbanProps.header || {}),
       }}
     >

--- a/app/manage-projects/[projectSlug]/contributions/_features/kanban-view/kanban-view.tsx
+++ b/app/manage-projects/[projectSlug]/contributions/_features/kanban-view/kanban-view.tsx
@@ -73,7 +73,7 @@ function Column({
       isFetchingNextPage={isFetchingNextPage}
       header={{
         title,
-        badge: { children: count, count },
+        badge: { count },
         ...(kanbanProps.header || {}),
       }}
     >

--- a/app/my-dashboard/contributions/_features/kanban-view/kanban-view.tsx
+++ b/app/my-dashboard/contributions/_features/kanban-view/kanban-view.tsx
@@ -72,7 +72,7 @@ function Column({
       isFetchingNextPage={isFetchingNextPage}
       header={{
         title,
-        badge: { children: count, count },
+        badge: { count },
         ...(kanbanProps.header || {}),
       }}
     >

--- a/app/my-dashboard/contributions/_features/kanban-view/kanban-view.tsx
+++ b/app/my-dashboard/contributions/_features/kanban-view/kanban-view.tsx
@@ -62,6 +62,8 @@ function Column({
     }
   }, [type]);
 
+  const count = data?.pages?.[0]?.totalItemNumber ?? 0;
+
   return (
     <KanbanColumn
       {...kanbanProps}
@@ -70,7 +72,7 @@ function Column({
       isFetchingNextPage={isFetchingNextPage}
       header={{
         title,
-        badge: { children: data?.pages?.[0]?.totalItemNumber ?? "0" },
+        badge: { children: count, count },
         ...(kanbanProps.header || {}),
       }}
     >

--- a/app/my-dashboard/contributions/_features/kanban-view/kanban-view.tsx
+++ b/app/my-dashboard/contributions/_features/kanban-view/kanban-view.tsx
@@ -62,7 +62,7 @@ function Column({
     }
   }, [type]);
 
-  const count = data?.pages?.[0]?.totalItemNumber ?? 0;
+  const count = useMemo(() => data?.pages?.[0]?.totalItemNumber ?? 0, [data]);
 
   return (
     <KanbanColumn

--- a/design-system/atoms/badge/adapters/default/default.adapter.tsx
+++ b/design-system/atoms/badge/adapters/default/default.adapter.tsx
@@ -30,7 +30,7 @@ export function BadgeDefaultAdapter<C extends ElementType = "span">({
   const _fixedSize = fixedSize || (count !== undefined && count < 10);
 
   const slots = BadgeDefaultVariants({ isDeletable, size, color, shape, iconOnly, variant, fixedSize: _fixedSize });
-  const showChildren = !!children || children === 0 || !!translate;
+  const showChildren = !!children || children === 0 || !!translate || !!count || count === 0;
 
   return (
     <Component {...htmlProps} className={cn(slots.base(), classNames?.base)}>
@@ -41,6 +41,7 @@ export function BadgeDefaultAdapter<C extends ElementType = "span">({
           <Typo size={"xs"} as={"span"} {...labelProps} classNames={{ base: cn(slots.label(), classNames?.label) }}>
             {children}
             {translate && <Translate {...translate} />}
+            {count}
           </Typo>
         )}
 

--- a/design-system/atoms/badge/adapters/default/default.adapter.tsx
+++ b/design-system/atoms/badge/adapters/default/default.adapter.tsx
@@ -21,13 +21,15 @@ export function BadgeDefaultAdapter<C extends ElementType = "span">({
   closeProps,
   variant,
   fixedSize = false,
+  count,
   ...props
 }: BadgePort<C>) {
   const { isDeletable, shape = "rounded", size = "sm", color, iconOnly } = props;
   const DefaultComponent = isDeletable ? "button" : "span";
   const Component = as || DefaultComponent;
+  const _fixedSize = fixedSize || (count !== undefined && count < 10);
 
-  const slots = BadgeDefaultVariants({ isDeletable, size, color, shape, iconOnly, variant, fixedSize });
+  const slots = BadgeDefaultVariants({ isDeletable, size, color, shape, iconOnly, variant, fixedSize: _fixedSize });
   const showChildren = !!children || children === 0 || !!translate;
 
   return (

--- a/design-system/atoms/badge/adapters/default/default.variants.ts
+++ b/design-system/atoms/badge/adapters/default/default.variants.ts
@@ -41,7 +41,9 @@ export const BadgeDefaultVariants = tv({
       true: {},
     },
     fixedSize: {
-      true: {},
+      true: {
+        base: "flex items-center justify-center !p-0",
+      },
     },
     color: {
       grey: {

--- a/design-system/atoms/badge/badge.types.ts
+++ b/design-system/atoms/badge/badge.types.ts
@@ -16,6 +16,7 @@ interface Variants {
   isDeletable: boolean;
   iconOnly: boolean;
   fixedSize: boolean;
+  count?: number;
   variant: "flat" | "outline" | "solid";
 }
 


### PR DESCRIPTION
- Added a `count` property to the badge types for better flexibility.
- Updated Kanban view components in both project and dashboard to use the new `count` property instead of directly accessing `totalItemNumber`.