### PR TITLE
Refactor matching questions to use answer values instead of indexes  …

### DIFF
--- a/app/project-recommendation/_features/matching-questions/_components/answer-grid/answer-grid.tsx
+++ b/app/project-recommendation/_features/matching-questions/_components/answer-grid/answer-grid.tsx
@@ -10,9 +10,9 @@ export function AnswerGrid({ answers, selectedAnswers, onAnswerSelect, isMultipl
       <div className="grid grid-cols-1 gap-md tablet:grid-cols-2">
         {answers.map(answer => (
           <MultipleChoiceAnswer
-            key={answer.index}
+            key={answer.value}
             answer={answer}
-            isSelected={selectedAnswers.find(a => a.index === answer.index)?.chosen ?? false}
+            isSelected={selectedAnswers.find(a => a.value === answer.value)?.chosen ?? false}
             onSelect={() => onAnswerSelect(answer)}
           />
         ))}
@@ -22,13 +22,13 @@ export function AnswerGrid({ answers, selectedAnswers, onAnswerSelect, isMultipl
 
   return (
     <RadioGroup
-      value={String(selectedAnswers[0]?.index ?? "-1")}
-      onChange={value => onAnswerSelect(answers.find(a => a.index === Number(value)) ?? answers[0])}
+      value={String(selectedAnswers[0]?.value ?? "-1")}
+      onChange={value => onAnswerSelect(answers.find(a => a.value === value) ?? answers[0])}
       as={SingleChoiceAnswer}
       items={answers.map(answer => ({
-        value: String(answer.index),
+        value: String(answer.value),
         componentProps: {
-          isSelected: selectedAnswers[0]?.index === answer.index,
+          isSelected: selectedAnswers[0]?.value === answer.value,
           answer,
         },
       }))}

--- a/app/project-recommendation/_features/matching-questions/matching-question.hooks.tsx
+++ b/app/project-recommendation/_features/matching-questions/matching-question.hooks.tsx
@@ -61,7 +61,7 @@ export function useMatchingQuestions() {
 
   function handleNext() {
     saveAnswers({
-      answerIndexes: questionState.selectedAnswers[currentQuestionId ?? ""].map(answer => answer.index ?? 0),
+      answerValues: questionState.selectedAnswers[currentQuestionId ?? ""].map(answer => answer.value ?? ""),
     });
   }
 
@@ -81,7 +81,7 @@ export function useMatchingQuestions() {
       const currentAnswers = prev.selectedAnswers[currentQuestion.id] ?? [];
 
       if (currentQuestion.multipleChoice) {
-        const existingAnswerIndex = currentAnswers.findIndex(a => a.index === answer.index);
+        const existingAnswerIndex = currentAnswers.findIndex(a => a.value === answer.value);
 
         if (existingAnswerIndex >= 0) {
           return {

--- a/app/project-recommendation/_features/matching-questions/matching-questions.types.ts
+++ b/app/project-recommendation/_features/matching-questions/matching-questions.types.ts
@@ -1,7 +1,7 @@
 export interface Answer {
-  index?: number;
   body: string;
   chosen: boolean;
+  value?: string;
 }
 
 export interface Question {


### PR DESCRIPTION
…- Updated the `Answer` interface to replace `index` with `value`. - Modified `useMatchingQuestions` hook to save and retrieve answers based on their `value`. - Adjusted `AnswerGrid` component to handle answer selection and rendering using `value` instead of `index`.  This change improves the clarity and consistency of answer handling in the matching questions feature.