### PR TITLE
Enhance Badge and Typo components with new style properties

### DIFF
--- a/design-system/atoms/badge/adapters/default/default.adapter.tsx
+++ b/design-system/atoms/badge/adapters/default/default.adapter.tsx
@@ -33,7 +33,7 @@ export function BadgeDefaultAdapter<C extends ElementType = "span">({
   const slots = BadgeDefaultVariants({ isDeletable, size, color, shape, iconOnly, variant, fixedSize: _fixedSize });
   const showChildren = !!children || children === 0 || !!translate || !!count || count === 0;
 
-  const s = useMemo(() => {
+  const baseStyles = useMemo(() => {
     if (styles) {
       return {
         ...(styles?.backgroundColor && { backgroundColor: styles?.backgroundColor }),
@@ -41,14 +41,23 @@ export function BadgeDefaultAdapter<C extends ElementType = "span">({
     }
     return {};
   }, [styles]);
+ 
+  const labelStyles = useMemo(() => {
+    if (styles) {
+      return {
+        ...(styles?.labelColor && { color: styles?.labelColor }),
+      };
+    }
+    return {};
+  }, [styles]);
 
   return (
-    <Component {...htmlProps} className={cn(slots.base(), classNames?.base)} style={s}>
+    <Component {...htmlProps} className={cn(slots.base(), classNames?.base)} style={baseStyles}>
       <div className={cn(slots.content(), classNames?.content)}>
         {startContent}
 
         {showChildren && (
-          <Typo size={"xs"} as={"span"} {...labelProps} classNames={{ base: cn(slots.label(), classNames?.label) }}>
+          <Typo size={"xs"} as={"span"} {...labelProps} classNames={{ base: cn(slots.label(), classNames?.label) }} style={labelStyles}>
             {children}
             {translate && <Translate {...translate} />}
             {count}

--- a/design-system/atoms/badge/badge.types.ts
+++ b/design-system/atoms/badge/badge.types.ts
@@ -11,6 +11,7 @@ import { TranslateProps } from "@/shared/translation/components/translate/transl
 
 interface Styles {
   backgroundColor: string;
+  labelColor: string;
 }
 
 interface Variants {

--- a/design-system/atoms/typo/adapters/default/default.adapter.tsx
+++ b/design-system/atoms/typo/adapters/default/default.adapter.tsx
@@ -13,6 +13,7 @@ export function TypoDefaultAdapter<C extends ElementType = "span">({
   translate,
   children,
   canHover = false,
+  style,
   ...props
 }: TypoPort<C>) {
   const Component = as || "span";
@@ -20,7 +21,7 @@ export function TypoDefaultAdapter<C extends ElementType = "span">({
   const slots = TypoDefaultVariants({ weight, variant, size, color, canHover, align });
 
   return (
-    <Component {...htmlProps} className={cn(slots.base(), classNames?.base)}>
+    <Component {...htmlProps} className={cn(slots.base(), classNames?.base)} style={style}>
       {translate ? <Translate {...translate} /> : children}
     </Component>
   );

--- a/design-system/atoms/typo/typo.types.ts
+++ b/design-system/atoms/typo/typo.types.ts
@@ -1,4 +1,4 @@
-import { ComponentProps, ComponentPropsWithoutRef, ElementType, PropsWithChildren } from "react";
+import { ComponentProps, ComponentPropsWithoutRef, CSSProperties, ElementType, PropsWithChildren } from "react";
 
 import { COLORS } from "@/shared/theme/colors";
 import { Translate } from "@/shared/translation/components/translate/translate";
@@ -26,4 +26,5 @@ export interface TypoPort<C extends ElementType> extends Partial<Variants>, Prop
   htmlProps?: ComponentPropsWithoutRef<C>;
   classNames?: Partial<ClassNames>;
   translate?: ComponentProps<typeof Translate>;
+  style?: Partial<CSSProperties>;
 }

--- a/design-system/molecules/cards/card-project-marketplace/adapters/default/default.adapter.tsx
+++ b/design-system/molecules/cards/card-project-marketplace/adapters/default/default.adapter.tsx
@@ -217,13 +217,17 @@ function Languages({ languages }: LanguagesProps) {
                 variant="outline"
                 shape="rounded"
                 size="xs"
-                classNames={{ base: "border-none w-full", content: "justify-between text-typography-primary-on-solid" }}
+                classNames={{
+                  base: "border-none w-full bg-opacity-20",
+                  content: "justify-between",
+                }}
                 avatar={{
                   src: language.logoUrl,
                   alt: language.name,
                 }}
                 styles={{
-                  backgroundColor: language.color,
+                  backgroundColor: language.color + "33", // 33 is 20% opacity
+                  labelColor: language.color,
                 }}
               >
                 {`${language.percentage.toFixed(0)}%`}


### PR DESCRIPTION
- Added `labelColor` property to Badge styles for better customization.
- Refactored BadgeDefaultAdapter to utilize `labelColor` in the label's style.
- Updated Typo component to accept a `style` prop for inline styling.
- Adjusted styles in card-project-marketplace to apply opacity to background colors and set label colors accordingly.