### PR TITLE
feat: enhance hover effect and card project marketplace types

### DIFF
--- a/design-system/molecules/cards/card-project-marketplace/_components/hover-effect/hover-effect.tsx
+++ b/design-system/molecules/cards/card-project-marketplace/_components/hover-effect/hover-effect.tsx
@@ -2,9 +2,11 @@ import { motion, useMotionValue, useTransform } from "framer-motion";
 import { useEffect, useState } from "react";
 import { useDebounce } from "react-use";
 
+import { HoverEffectProps } from "@/design-system/molecules/cards/card-project-marketplace/_components/hover-effect/hover-effect.types";
+
 import { cn } from "@/shared/helpers/cn";
 
-export function HoverEffect({ cardRef }: { cardRef: React.RefObject<HTMLDivElement> }) {
+export function HoverEffect({ cardRef, showBorder = false }: HoverEffectProps) {
   const mouseX = useMotionValue(0);
   const mouseY = useMotionValue(0);
   const [isHovered, setIsHovered] = useState(false);
@@ -57,12 +59,12 @@ export function HoverEffect({ cardRef }: { cardRef: React.RefObject<HTMLDivEleme
       className={cn(
         "absolute inset-[-2px] z-10 overflow-hidden rounded-[12px] opacity-0 transition-opacity duration-500 ease-in",
         {
-          "opacity-100": isHovered,
+          "opacity-100": isHovered || showBorder,
         }
       )}
     >
       <div className="absolute left-1/2 top-1/2 aspect-square w-[200%] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-[10px]">
-        {isHoveredDebounced && (
+        {(isHoveredDebounced || showBorder) && (
           <motion.div
             className="card-hover-gradient-solid absolute inset-0"
             animate={{ rotate: 360 }}

--- a/design-system/molecules/cards/card-project-marketplace/_components/hover-effect/hover-effect.types.ts
+++ b/design-system/molecules/cards/card-project-marketplace/_components/hover-effect/hover-effect.types.ts
@@ -1,0 +1,4 @@
+export type HoverEffectProps = {
+  cardRef: React.RefObject<HTMLDivElement>;
+  showBorder?: boolean;
+};

--- a/design-system/molecules/cards/card-project-marketplace/adapters/default/default.adapter.tsx
+++ b/design-system/molecules/cards/card-project-marketplace/adapters/default/default.adapter.tsx
@@ -127,7 +127,12 @@ export function CardProjectMarketplaceDefaultAdapter<C extends ElementType = "di
       classNames={{ base: cn(slots.base(), classNames?.base) }}
     >
       <div ref={cardRef} className="flex h-full w-full flex-col">
-        <HoverEffect cardRef={cardRef} />
+        <HoverEffect
+          cardRef={cardRef}
+          showBorder={Boolean(
+            ecosystems?.find(ecosystem => ecosystem.slug === "stellar" || ecosystem.slug === "starknet")
+          )}
+        />
 
         <div className="relative z-20 flex h-full flex-col justify-between gap-2lg rounded-md border-border-primary p-xl">
           <div className="flex flex-col gap-2lg">

--- a/design-system/molecules/cards/card-project-marketplace/card-project-marketplace.types.ts
+++ b/design-system/molecules/cards/card-project-marketplace/card-project-marketplace.types.ts
@@ -28,6 +28,7 @@ export interface CardProjectMarketplacePort<C extends ElementType> {
   ecosystems?: {
     id: string;
     name: string;
+    slug: string;
     logoUrl: string;
   }[];
   onClick?: () => void;


### PR DESCRIPTION
- Added a new 'slug' property to the ecosystems interface in card-project-marketplace.types.ts for better ecosystem identification.
- Introduced HoverEffectProps type to define props for the HoverEffect component, including an optional 'showBorder' property.
- Updated the HoverEffect component to conditionally display a border based on the 'showBorder' prop.
- Modified the CardProjectMarketplaceDefaultAdapter to pass the 'showBorder' prop based on the presence of specific ecosystems.

These changes improve the flexibility and usability of the card project marketplace components.