### PR TITLE
feat: integrate Posthog tracking across Hackathons and Projects pages

### DIFF
--- a/app/hackathons/[hackathonSlug]/community/page.tsx
+++ b/app/hackathons/[hackathonSlug]/community/page.tsx
@@ -4,6 +4,7 @@ import { HackathonReactQueryAdapter } from "@/core/application/react-query-adapt
 
 import { ScrollView } from "@/shared/components/scroll-view/scroll-view";
 import { NavigationBreadcrumb } from "@/shared/features/navigation/navigation.context";
+import { PosthogCaptureOnMount } from "@/shared/tracking/posthog/posthog-capture-on-mount/posthog-capture-on-mount";
 import { Translate } from "@/shared/translation/components/translate/translate";
 
 export default function HackathonCommunityPage({ params: { hackathonSlug } }: { params: { hackathonSlug: string } }) {
@@ -18,6 +19,14 @@ export default function HackathonCommunityPage({ params: { hackathonSlug } }: { 
 
   return (
     <ScrollView>
+      <PosthogCaptureOnMount
+        eventName={"hackathon_viewed"}
+        params={{
+          hackathon_id: hackathon?.id,
+        }}
+        paramsReady={Boolean(hackathon?.id)}
+      />
+
       <NavigationBreadcrumb
         breadcrumb={[
           {

--- a/app/hackathons/[hackathonSlug]/overview/page.tsx
+++ b/app/hackathons/[hackathonSlug]/overview/page.tsx
@@ -8,6 +8,7 @@ import { HackathonReactQueryAdapter } from "@/core/application/react-query-adapt
 import { ScrollView } from "@/shared/components/scroll-view/scroll-view";
 import { NEXT_ROUTER } from "@/shared/constants/router";
 import { NavigationBreadcrumb } from "@/shared/features/navigation/navigation.context";
+import { PosthogCaptureOnMount } from "@/shared/tracking/posthog/posthog-capture-on-mount/posthog-capture-on-mount";
 import { Translate } from "@/shared/translation/components/translate/translate";
 
 export default function HackathonOverviewPage({ params: { hackathonSlug } }: { params: { hackathonSlug: string } }) {
@@ -22,6 +23,14 @@ export default function HackathonOverviewPage({ params: { hackathonSlug } }: { p
 
   return (
     <ScrollView>
+      <PosthogCaptureOnMount
+        eventName={"hackathon_viewed"}
+        params={{
+          hackathon_id: hackathon?.id,
+        }}
+        paramsReady={Boolean(hackathon?.id)}
+      />
+
       <NavigationBreadcrumb
         breadcrumb={[
           {

--- a/app/hackathons/[hackathonSlug]/projects/page.tsx
+++ b/app/hackathons/[hackathonSlug]/projects/page.tsx
@@ -23,6 +23,7 @@ import { FilterButton } from "@/shared/features/filters/_components/filter-butto
 import { FilterDataProvider } from "@/shared/features/filters/_contexts/filter-data/filter-data.context";
 import { NavigationBreadcrumb } from "@/shared/features/navigation/navigation.context";
 import { cn } from "@/shared/helpers/cn";
+import { PosthogCaptureOnMount } from "@/shared/tracking/posthog/posthog-capture-on-mount/posthog-capture-on-mount";
 import { Translate } from "@/shared/translation/components/translate/translate";
 
 import { FilterData } from "./_components/filter-data/filter-data";
@@ -158,6 +159,14 @@ export default function HackathonProjectsPage({ params }: { params: { hackathonS
 
   return (
     <FilterDataProvider filters={filters} setFilters={setFilters}>
+      <PosthogCaptureOnMount
+        eventName={"hackathon_viewed"}
+        params={{
+          hackathon_id: hackathon?.id,
+        }}
+        paramsReady={Boolean(hackathon?.id)}
+      />
+
       <NavigationBreadcrumb
         breadcrumb={[
           {

--- a/app/hackathons/_features/register-hackathon/register-hackathon.tsx
+++ b/app/hackathons/_features/register-hackathon/register-hackathon.tsx
@@ -9,7 +9,11 @@ import { Button } from "@/design-system/atoms/button/variants/button-default";
 import { Tooltip } from "@/design-system/atoms/tooltip";
 import { toast } from "@/design-system/molecules/toaster";
 
+import { usePosthog } from "@/shared/tracking/posthog/use-posthog";
+
 export function RegisterHackathon({ hackathonSlug }: RegisterHackathonProps) {
+  const { capture } = usePosthog();
+
   const {
     data: hackathon,
     isLoading: hackathonIsLoading,
@@ -50,6 +54,8 @@ export function RegisterHackathon({ hackathonSlug }: RegisterHackathonProps) {
     options: {
       onSuccess: () => {
         toast.success(`Registered to ${hackathon?.title}`);
+
+        capture("hackathon_registration", { hackathon_id: hackathon?.id });
       },
       onError: () => {
         toast.error(`Error registering to ${hackathon?.title}`);

--- a/app/hackathons/page.tsx
+++ b/app/hackathons/page.tsx
@@ -9,11 +9,14 @@ import { HackathonList } from "@/app/hackathons/_features/hackathon-list/hackath
 import { withClientOnly } from "@/shared/components/client-only/client-only";
 import { ListBanner } from "@/shared/features/list-banner/list-banner";
 import { NavigationBreadcrumb } from "@/shared/features/navigation/navigation.context";
+import { PosthogCaptureOnMount } from "@/shared/tracking/posthog/posthog-capture-on-mount/posthog-capture-on-mount";
 import { Translate } from "@/shared/translation/components/translate/translate";
 
 function HackathonsPage() {
   return (
     <div className="pb-7xl">
+      <PosthogCaptureOnMount eventName={"hackathon_list_viewed"} />
+
       <NavigationBreadcrumb
         breadcrumb={[
           {

--- a/app/projects/[projectSlug]/contributors/page.tsx
+++ b/app/projects/[projectSlug]/contributors/page.tsx
@@ -6,6 +6,7 @@ import { ProjectReactQueryAdapter } from "@/core/application/react-query-adapter
 
 import { ScrollView } from "@/shared/components/scroll-view/scroll-view";
 import { NavigationBreadcrumb } from "@/shared/features/navigation/navigation.context";
+import { PosthogCaptureOnMount } from "@/shared/tracking/posthog/posthog-capture-on-mount/posthog-capture-on-mount";
 import { Translate } from "@/shared/translation/components/translate/translate";
 
 import { ContributorsTable } from "./_components/contributors-table/contributors-table";
@@ -22,6 +23,18 @@ export default function ProjectContributorsPage({ params }: { params: { projectS
 
   return (
     <ScrollView>
+      <PosthogCaptureOnMount
+        eventName={"project_viewed"}
+        params={{
+          id_project: data?.id,
+          project_id: data?.id,
+          type: "full",
+          issues: data?.availableIssueCount,
+          tab: "contributors",
+        }}
+        paramsReady={Boolean(data)}
+      />
+
       <NavigationBreadcrumb
         breadcrumb={[
           {

--- a/app/projects/[projectSlug]/issues/page.tsx
+++ b/app/projects/[projectSlug]/issues/page.tsx
@@ -18,6 +18,7 @@ import { EmptyState } from "@/shared/components/empty-state/empty-state";
 import { ScrollView } from "@/shared/components/scroll-view/scroll-view";
 import { NavigationBreadcrumb } from "@/shared/features/navigation/navigation.context";
 import { useApplyIssueSidePanel } from "@/shared/panels/apply-issue-sidepanel/apply-issue-sidepanel.hooks";
+import { PosthogCaptureOnMount } from "@/shared/tracking/posthog/posthog-capture-on-mount/posthog-capture-on-mount";
 import { Translate } from "@/shared/translation/components/translate/translate";
 
 export default function ProjectIssuesPage({
@@ -128,6 +129,18 @@ export default function ProjectIssuesPage({
 
   return (
     <ScrollView>
+      <PosthogCaptureOnMount
+        eventName={"project_viewed"}
+        params={{
+          id_project: data?.id,
+          project_id: data?.id,
+          type: "full",
+          issues: data?.availableIssueCount,
+          tab: "issues",
+        }}
+        paramsReady={Boolean(data)}
+      />
+
       <NavigationBreadcrumb
         breadcrumb={[
           {

--- a/app/projects/[projectSlug]/overview/page.tsx
+++ b/app/projects/[projectSlug]/overview/page.tsx
@@ -6,6 +6,7 @@ import { ProjectReactQueryAdapter } from "@/core/application/react-query-adapter
 
 import { ScrollView } from "@/shared/components/scroll-view/scroll-view";
 import { NavigationBreadcrumb } from "@/shared/features/navigation/navigation.context";
+import { PosthogCaptureOnMount } from "@/shared/tracking/posthog/posthog-capture-on-mount/posthog-capture-on-mount";
 import { Translate } from "@/shared/translation/components/translate/translate";
 
 import { Description } from "./_features/description/description";
@@ -23,6 +24,18 @@ export default function ProjectOverviewPage({ params }: { params: { projectSlug:
 
   return (
     <ScrollView>
+      <PosthogCaptureOnMount
+        eventName={"project_viewed"}
+        params={{
+          id_project: data?.id,
+          project_id: data?.id,
+          type: "full",
+          issues: data?.availableIssueCount,
+          tab: "overview",
+        }}
+        paramsReady={Boolean(data)}
+      />
+
       <NavigationBreadcrumb
         breadcrumb={[
           {

--- a/app/projects/[projectSlug]/rewards/page.tsx
+++ b/app/projects/[projectSlug]/rewards/page.tsx
@@ -6,6 +6,7 @@ import { ProjectReactQueryAdapter } from "@/core/application/react-query-adapter
 
 import { ScrollView } from "@/shared/components/scroll-view/scroll-view";
 import { NavigationBreadcrumb } from "@/shared/features/navigation/navigation.context";
+import { PosthogCaptureOnMount } from "@/shared/tracking/posthog/posthog-capture-on-mount/posthog-capture-on-mount";
 import { Translate } from "@/shared/translation/components/translate/translate";
 
 import { RewardsTable } from "./_components/rewards-table/rewards-table";
@@ -22,6 +23,18 @@ export default function ProjectRewardsPage({ params }: { params: { projectSlug: 
 
   return (
     <ScrollView>
+      <PosthogCaptureOnMount
+        eventName={"project_viewed"}
+        params={{
+          id_project: data?.id,
+          project_id: data?.id,
+          type: "full",
+          issues: data?.availableIssueCount,
+          tab: "rewards",
+        }}
+        paramsReady={Boolean(data)}
+      />
+
       <NavigationBreadcrumb
         breadcrumb={[
           {


### PR DESCRIPTION
- Added PosthogCaptureOnMount component to HackathonsPage, HackathonCommunityPage, HackathonOverviewPage, and HackathonProjectsPage to track hackathon views.
- Implemented PosthogCaptureOnMount in ProjectContributorsPage, ProjectIssuesPage, ProjectOverviewPage, and ProjectRewardsPage to track project views.
- Enhanced RegisterHackathon component to capture registration events with hackathon ID.
- Improved tracking parameters for better analytics insights.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added event tracking for various pages including hackathons, projects, and their respective sections
	- Implemented PostHog tracking to capture user interactions and page views
	- Enhanced analytics capabilities across the platform

- **Tracking Improvements**
	- Added tracking for hackathon list, registration, and individual hackathon page views
	- Implemented detailed tracking for project pages, including overview, contributors, issues, and rewards sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->