### PR TITLE
Add repository display to project overview card

### DIFF
--- a/app/projects/_features/project-details/project-overview-summary/project-overview-summary.tsx
+++ b/app/projects/_features/project-details/project-overview-summary/project-overview-summary.tsx
@@ -47,6 +47,7 @@ export function ProjectOverviewSummary({ projectIdOrSlug }: ProjectOverviewSumma
         languages={project.languages}
         moreInfos={project.moreInfos}
         leaders={project.leads}
+        repos={project.repos}
       />
     );
   }, [isLoading, isError, project]);

--- a/core/domain/project/models/project-model-v2.ts
+++ b/core/domain/project/models/project-model-v2.ts
@@ -29,6 +29,7 @@ export class ProjectV2 implements ProjectInterfaceV2 {
   currentWeekAvailableIssueCount!: ProjectResponseV2["currentWeekAvailableIssueCount"];
   currentWeekMergedPrCount!: ProjectResponseV2["currentWeekMergedPrCount"];
   tags!: ProjectResponseV2["tags"];
+  repos!: ProjectResponseV2["repos"];
 
   constructor(props: ProjectResponseV2) {
     Object.assign(this, props);

--- a/design-system/molecules/cards/card-project-overview/_translations/card-project-overview.en.json
+++ b/design-system/molecules/cards/card-project-overview/_translations/card-project-overview.en.json
@@ -1,5 +1,6 @@
 {
   "description": "Description",
   "languages": "Languages",
-  "socials": "Socials"
+  "socials": "Socials",
+  "repos": "Repos"
 }

--- a/design-system/molecules/cards/card-project-overview/adapters/default/default.adapter.tsx
+++ b/design-system/molecules/cards/card-project-overview/adapters/default/default.adapter.tsx
@@ -8,6 +8,7 @@ import { Typo } from "@/design-system/atoms/typo";
 import { Categories } from "@/shared/features/projects/categories/categories";
 import { Languages } from "@/shared/features/projects/languages/languages";
 import { Metric } from "@/shared/features/projects/metric/metric";
+import { RepoLink } from "@/shared/features/repos/repo-link/repo-link";
 import { ProjectMoreInfo } from "@/shared/features/social/project-more-info/project-more-info";
 import { UserGroup } from "@/shared/features/user/user-group/user-group";
 import { cn } from "@/shared/helpers/cn";
@@ -29,6 +30,7 @@ export function CardProjectOverviewDefaultAdapter<C extends ElementType = "div">
   languages,
   moreInfos,
   leaders,
+  repos,
 }: CardProjectOverviewPort<C>) {
   const slots = CardProjectOverviewDefaultVariants();
 
@@ -106,6 +108,20 @@ export function CardProjectOverviewDefaultAdapter<C extends ElementType = "div">
                 {moreInfos?.map(moreInfoItem => (
                   <ProjectMoreInfo key={moreInfoItem.url} moreInfoItem={moreInfoItem} buttonProps={{ size: "xs" }} />
                 ))}
+              </div>
+            </div>
+          ) : null}
+
+          {repos ? (
+            <div className="flex flex-col gap-lg">
+              <Typo
+                size="xs"
+                weight="medium"
+                color="primary"
+                translate={{ token: "features:cardProjectOverview.repos" }}
+              />
+              <div className={"flex flex-row flex-wrap gap-sm"}>
+                {repos?.map(repo => <RepoLink key={repo.htmlUrl} repo={repo} buttonProps={{ size: "xs" }} />)}
               </div>
             </div>
           ) : null}

--- a/design-system/molecules/cards/card-project-overview/card-project-overview.types.ts
+++ b/design-system/molecules/cards/card-project-overview/card-project-overview.types.ts
@@ -1,7 +1,6 @@
 import { ComponentPropsWithoutRef, ElementType } from "react";
 
 import { ProjectInterfaceV2 } from "@/core/domain/project/models/project-model-v2";
-import { components } from "@/core/infrastructure/marketplace-api-client-adapter/__generated/api";
 
 import { CategoriesProps } from "@/shared/features/projects/categories/categories.types";
 import { LanguagesProps } from "@/shared/features/projects/languages/languages.types";
@@ -24,5 +23,5 @@ export interface CardProjectOverviewPort<C extends ElementType> {
   leaders?: ProjectInterfaceV2["leads"];
   languages?: LanguagesProps["languages"];
   moreInfos?: ProjectInterfaceV2["moreInfos"];
-  repos?: components["schemas"]["ShortGithubRepoResponse"][];
+  repos?: ProjectInterfaceV2["repos"];
 }

--- a/design-system/molecules/cards/card-project-overview/card-project-overview.types.ts
+++ b/design-system/molecules/cards/card-project-overview/card-project-overview.types.ts
@@ -1,6 +1,7 @@
 import { ComponentPropsWithoutRef, ElementType } from "react";
 
 import { ProjectInterfaceV2 } from "@/core/domain/project/models/project-model-v2";
+import { components } from "@/core/infrastructure/marketplace-api-client-adapter/__generated/api";
 
 import { CategoriesProps } from "@/shared/features/projects/categories/categories.types";
 import { LanguagesProps } from "@/shared/features/projects/languages/languages.types";
@@ -23,4 +24,5 @@ export interface CardProjectOverviewPort<C extends ElementType> {
   leaders?: ProjectInterfaceV2["leads"];
   languages?: LanguagesProps["languages"];
   moreInfos?: ProjectInterfaceV2["moreInfos"];
+  repos?: components["schemas"]["ShortGithubRepoResponse"][];
 }

--- a/shared/features/repos/repo-link/repo-link.tsx
+++ b/shared/features/repos/repo-link/repo-link.tsx
@@ -11,7 +11,7 @@ import { RepoLinkProps } from "./repo-link.types";
 export function RepoLink({ repo, buttonProps }: RepoLinkProps) {
   const urlKernelPort = bootstrap.getUrlKernelPort();
 
-  if (!repo?.htmlUrl) return null;
+  if (!repo || !repo?.htmlUrl || !repo?.name) return null;
 
   return (
     <Button

--- a/shared/features/repos/repo-link/repo-link.tsx
+++ b/shared/features/repos/repo-link/repo-link.tsx
@@ -1,0 +1,24 @@
+import { bootstrap } from "@/core/bootstrap";
+
+import { Button } from "@/design-system/atoms/button/variants/button-default";
+import { Icon } from "@/design-system/atoms/icon";
+
+import { Github } from "@/shared/icons";
+
+import { RepoLinkProps } from "./repo-link.types";
+
+export function RepoLink({ repo, buttonProps }: RepoLinkProps) {
+  const urlKernelPort = bootstrap.getUrlKernelPort();
+  return (
+    <Button
+      as={"a"}
+      variant={"secondary"}
+      size={"sm"}
+      startContent={<Icon component={Github} />}
+      {...buttonProps}
+      htmlProps={{ href: urlKernelPort.validateUrl(repo?.htmlUrl ?? ""), target: "_blank" }}
+    >
+      {repo?.name}
+    </Button>
+  );
+}

--- a/shared/features/repos/repo-link/repo-link.tsx
+++ b/shared/features/repos/repo-link/repo-link.tsx
@@ -3,20 +3,26 @@ import { bootstrap } from "@/core/bootstrap";
 import { Button } from "@/design-system/atoms/button/variants/button-default";
 import { Icon } from "@/design-system/atoms/icon";
 
+import { BaseLink } from "@/shared/components/base-link/base-link";
 import { Github } from "@/shared/icons";
 
 import { RepoLinkProps } from "./repo-link.types";
 
 export function RepoLink({ repo, buttonProps }: RepoLinkProps) {
   const urlKernelPort = bootstrap.getUrlKernelPort();
+
+  if (!repo?.htmlUrl) return null;
+
   return (
     <Button
-      as={"a"}
+      as={BaseLink}
       variant={"secondary"}
       size={"sm"}
       startContent={<Icon component={Github} />}
+      htmlProps={{
+        href: urlKernelPort.validateUrl(repo?.htmlUrl ?? ""),
+      }}
       {...buttonProps}
-      htmlProps={{ href: urlKernelPort.validateUrl(repo?.htmlUrl ?? ""), target: "_blank" }}
     >
       {repo?.name}
     </Button>

--- a/shared/features/repos/repo-link/repo-link.types.ts
+++ b/shared/features/repos/repo-link/repo-link.types.ts
@@ -1,0 +1,9 @@
+import { components } from "@/core/infrastructure/marketplace-api-client-adapter/__generated/api";
+import { AnyType } from "@/core/kernel/types";
+
+import { ButtonPort } from "@/design-system/atoms/button/button.types";
+
+export interface RepoLinkProps {
+  repo?: components["schemas"]["ShortGithubRepoResponse"];
+  buttonProps?: ButtonPort<AnyType>;
+}

--- a/shared/features/repos/repo-link/repo-link.types.ts
+++ b/shared/features/repos/repo-link/repo-link.types.ts
@@ -1,9 +1,9 @@
-import { components } from "@/core/infrastructure/marketplace-api-client-adapter/__generated/api";
+import { ProjectInterfaceV2 } from "@/core/domain/project/models/project-model-v2";
 import { AnyType } from "@/core/kernel/types";
 
 import { ButtonPort } from "@/design-system/atoms/button/button.types";
 
 export interface RepoLinkProps {
-  repo?: components["schemas"]["ShortGithubRepoResponse"];
+  repo?: ProjectInterfaceV2["repos"][number];
   buttonProps?: ButtonPort<AnyType>;
 }


### PR DESCRIPTION
…ectOverviewSummary to include repositories in the project details. - Enhanced CardProjectOverview types to support repositories. - Added translation for 'repos' in the project overview card. - Implemented rendering of repositories in the CardProjectOverviewDefaultAdapter.  This update improves the visibility of project repositories, enhancing user experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added repository information display for projects.
	- Introduced a new `RepoLink` component to show GitHub repository links.
	- Enhanced project overview with repository details.

- **Translations**
	- Added "Repos" translation for repository section.

- **Improvements**
	- Updated project overview card to support repository information.
	- Implemented flexible repository link rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->