### PR TITLE
Refactor project list to use category ID instead of slug

### DIFF
--- a/app/(saas)/categories/[categorySlug]/_features/project-list/project-list.tsx
+++ b/app/(saas)/categories/[categorySlug]/_features/project-list/project-list.tsx
@@ -21,7 +21,7 @@ import { useCategoriesProjectsFilterDataSidePanel } from "../filter-data/filter-
 
 export type ProjectsFilters = Omit<NonNullable<GetProjectsV2QueryParams>, "pageSize" | "pageIndex">;
 
-export default function ProjectList({ params }: { params: { categorySlug: string } }) {
+export default function ProjectList({ categoryId }: { categoryId: string }) {
   const [search, setSearch] = useState<string>();
   const { open: openFilterPanel } = useCategoriesProjectsFilterDataSidePanel();
   const [filters, setFilters] = useState<ProjectsFilters>({});
@@ -29,14 +29,12 @@ export default function ProjectList({ params }: { params: { categorySlug: string
 
   const queryParams: Partial<GetProjectsV2QueryParams> = {
     search: debouncedSearch,
+    categoryIds: [categoryId],
     ...filters,
   };
 
   const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
     ProjectReactQueryAdapter.client.useGetProjectsV2({
-      pathParams: {
-        categorySlug: params.categorySlug,
-      },
       queryParams,
     });
 

--- a/app/(saas)/categories/[categorySlug]/page.tsx
+++ b/app/(saas)/categories/[categorySlug]/page.tsx
@@ -89,7 +89,7 @@ function CategoryPage({ params }: { params: { categorySlug: string } }) {
           />
         </div>
 
-        <ProjectList params={{ categorySlug: params.categorySlug }} />
+        <ProjectList categoryId={category.id} />
       </div>
     </PageWrapper>
   );

--- a/core/application/react-query-adapter/project/client/use-get-projects-v2.ts
+++ b/core/application/react-query-adapter/project/client/use-get-projects-v2.ts
@@ -9,7 +9,6 @@ import { ProjectFacadePort } from "@/core/domain/project/input/project-facade-po
 import { GetProjectsV2Model } from "@/core/domain/project/project-contract.types";
 
 export function useGetProjectsV2({
-  pathParams,
   queryParams,
   options,
 }: UseInfiniteQueryFacadeParams<ProjectFacadePort["getProjectsV2"], GetProjectsV2Model>) {
@@ -17,7 +16,6 @@ export function useGetProjectsV2({
 
   return useInfiniteQuery(
     useInfiniteQueryAdapter<ProjectFacadePort["getProjectsV2"], GetProjectsV2Model>({
-      pathParams,
       queryParams,
       options,
       httpStorage: projectStoragePort.getProjectsV2,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated project list component to use category ID directly instead of slug
	- Simplified parameter handling for project fetching logic
	- Removed unnecessary path parameters from project query function

- **Technical Improvement**
	- Streamlined data fetching approach for project lists
	- Enhanced component interface for more direct category filtering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->