### PR TITLE
Fix currency display in invoice

### DIFF
--- a/core/kernel/money/money-adapter.ts
+++ b/core/kernel/money/money-adapter.ts
@@ -123,7 +123,6 @@ export class MoneyAdapter implements MoneyFacadePort {
 
     return new Intl.NumberFormat(locale, {
       maximumFractionDigits,
-      maximumSignificantDigits: this.maximumSignificantDigits,
       ...options,
     })
       .format(amount)

--- a/shared/features/amount-selector/_components/amount-field/amount-field.tsx
+++ b/shared/features/amount-selector/_components/amount-field/amount-field.tsx
@@ -75,6 +75,7 @@ export function AmountField({ onAmountChange, amount, readOnly, isFilled, budget
     const { amount: formattedCurrencyAmount } = format({
       amount: parseFloat(amount),
       currency: budget.currency,
+      options: { maximumSignificantDigits },
     });
 
     if (isConversionFirst) {

--- a/shared/features/invoice/sections/invoice-summary.tsx
+++ b/shared/features/invoice/sections/invoice-summary.tsx
@@ -47,7 +47,7 @@ export function InvoiceSummary({
                 <Text style={invoiceStyles.td}>{dateKernelPort.format(new Date(item.date), "MM/dd/yyyy")}</Text>
                 {/*  amount  */}
                 <Text style={invoiceStyles.td}>
-                  {moneyKernelPort.format({ amount: item.amount.prettyAmount, currency: item.amount.currency }).amount}
+                  {item.amount.prettyAmount} {item.amount.currency.code}
                 </Text>
                 {/*  rate  */}
                 <View style={{ ...invoiceStyles.td, ...invoiceStyles.flexRow }}>
@@ -122,7 +122,7 @@ export function InvoiceSummary({
         <Text style={invoiceStyles.h4}>{InvoiceTokens.rewardSummary.specialMentions}</Text>
         {totalAfterTaxPerCurrency?.map((item, index) => (
           <Text key={index} style={invoiceStyles.paragraph}>
-            - {moneyKernelPort.format({ amount: item.amount, currency: item.currency }).amount}
+            - {moneyKernelPort.format({ amount: item.amount, currency: item.currency }).amount} {item.currency.code}
             {vat.vatRegulationState === "VAT_APPLICABLE" ? InvoiceTokens.rewardSummary.includingVat : " "}
             {InvoiceTokens.rewardSummary.itemsReceived}
           </Text>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated monetary formatting across the app. Invoice summaries now display rewards, totals, and conversion rates with a clear separation between the numerical value and the currency code.
  - Enhanced amount field displays now use refined formatting options for greater consistency and readability.
  - These changes provide a clearer, more consistent presentation of financial data across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->