### PR TITLE
Fix timezone for charts

### DIFF
--- a/app/(saas)/data/_components/histograms/histograms.utils.ts
+++ b/app/(saas)/data/_components/histograms/histograms.utils.ts
@@ -14,16 +14,24 @@ export function buildCategories({
   const dateKernelPort = bootstrap.getDateKernelPort();
   if (timeGroupingType === TimeGroupingType.DAY || timeGroupingType === TimeGroupingType.WEEK) {
     return (
-      stats?.map(stat => dateKernelPort.formatInTimeZone(new Date(stat.timestamp), "Europe/Paris", "yyyy-MM-dd")) ?? []
+      stats?.map(stat =>
+        dateKernelPort.format(new Date(stat.timestamp.substring(0, stat.timestamp.length - 1)), "yyyy-MM-dd")
+      ) ?? []
     );
   }
 
   if (timeGroupingType === TimeGroupingType.YEAR) {
-    return stats?.map(stat => dateKernelPort.formatInTimeZone(new Date(stat.timestamp), "Europe/Paris", "yyyy")) ?? [];
+    return (
+      stats?.map(stat =>
+        dateKernelPort.format(new Date(stat.timestamp.substring(0, stat.timestamp.length - 1)), "yyyy")
+      ) ?? []
+    );
   }
 
   return (
-    stats?.map(stat => dateKernelPort.formatInTimeZone(new Date(stat.timestamp), "Europe/Paris", "MMMM yyyy")) ?? []
+    stats?.map(stat =>
+      dateKernelPort.format(new Date(stat.timestamp.substring(0, stat.timestamp.length - 1)), "MMMM yyyy")
+    ) ?? []
   );
 }
 

--- a/app/(saas)/data/_components/histograms/histograms.utils.ts
+++ b/app/(saas)/data/_components/histograms/histograms.utils.ts
@@ -13,14 +13,18 @@ export function buildCategories({
 }) {
   const dateKernelPort = bootstrap.getDateKernelPort();
   if (timeGroupingType === TimeGroupingType.DAY || timeGroupingType === TimeGroupingType.WEEK) {
-    return stats?.map(stat => dateKernelPort.format(new Date(stat.timestamp), "yyyy-MM-dd")) ?? [];
+    return (
+      stats?.map(stat => dateKernelPort.formatInTimeZone(new Date(stat.timestamp), "Europe/Paris", "yyyy-MM-dd")) ?? []
+    );
   }
 
   if (timeGroupingType === TimeGroupingType.YEAR) {
-    return stats?.map(stat => dateKernelPort.format(new Date(stat.timestamp), "yyyy")) ?? [];
+    return stats?.map(stat => dateKernelPort.formatInTimeZone(new Date(stat.timestamp), "Europe/Paris", "yyyy")) ?? [];
   }
 
-  return stats?.map(stat => dateKernelPort.format(new Date(stat.timestamp), "MMMM yyyy")) ?? [];
+  return (
+    stats?.map(stat => dateKernelPort.formatInTimeZone(new Date(stat.timestamp), "Europe/Paris", "MMMM yyyy")) ?? []
+  );
 }
 
 export function isSplineType(value: string): value is SplineType {

--- a/shared/charts/budget-in-time/budget-in-time.hooks.ts
+++ b/shared/charts/budget-in-time/budget-in-time.hooks.ts
@@ -7,8 +7,7 @@ import { BiStatsFinancialsResponse } from "@/core/domain/bi/models/bi-stats-fina
 export function useBudgetInTimeChart(stats?: GetBiStatsFinancialsModel["stats"]) {
   const dateKernelPort = bootstrap.getDateKernelPort();
 
-  const categories =
-    stats?.map(stat => dateKernelPort.formatInTimeZone(new Date(stat.date), "Europe/Paris", "MMMM yyyy")) ?? [];
+  const categories = stats?.map(stat => dateKernelPort.format(new Date(`${stat.date}T00:00:00`), "MMMM yyyy")) ?? [];
 
   const calculateSeries = (key: keyof BiStatsFinancialsResponse) => {
     return stats?.map(stat => stat?.getStatTotalUsdEquivalent(key)) ?? [];

--- a/shared/charts/budget-in-time/budget-in-time.hooks.ts
+++ b/shared/charts/budget-in-time/budget-in-time.hooks.ts
@@ -7,7 +7,8 @@ import { BiStatsFinancialsResponse } from "@/core/domain/bi/models/bi-stats-fina
 export function useBudgetInTimeChart(stats?: GetBiStatsFinancialsModel["stats"]) {
   const dateKernelPort = bootstrap.getDateKernelPort();
 
-  const categories = stats?.map(stat => dateKernelPort.format(new Date(stat.date), "MMMM yyyy")) ?? [];
+  const categories =
+    stats?.map(stat => dateKernelPort.formatInTimeZone(new Date(stat.date), "Europe/Paris", "MMMM yyyy")) ?? [];
 
   const calculateSeries = (key: keyof BiStatsFinancialsResponse) => {
     return stats?.map(stat => stat?.getStatTotalUsdEquivalent(key)) ?? [];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved date display in charts and histograms to consistently reflect the Europe/Paris timezone. Dates now appear in a standardized format—using "yyyy-MM-dd" for day and week views, "yyyy" for yearly, and "MMMM yyyy" for broader ranges—ensuring clearer and more uniform visualization throughout the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->