### PR TITLE
Sb 42 maintain filters when returning to browse section in stellar

### DIFF
--- a/app/(saas)/projects/_features/browse-projects-filters/browse-projects-filters.context.tsx
+++ b/app/(saas)/projects/_features/browse-projects-filters/browse-projects-filters.context.tsx
@@ -3,7 +3,6 @@ import { useDebounce } from "react-use";
 
 import { ProjectTag } from "@/core/domain/project/project.types";
 
-import { useDeleteSearchParams } from "@/shared/hooks/router/use-delete-search-params";
 import { useUpdateMultipleSearchParams } from "@/shared/hooks/router/use-update-search-params";
 
 import {
@@ -25,20 +24,49 @@ const BrowseProjectsContext = createContext<BrowseProjectsContextReturn>({
   queryParams: {},
 });
 
+function getFilterFromSearchParams(getSearchParams: URLSearchParams) {
+  const sortByParam = getSearchParams.get("sortBy");
+  const tagsParam = getSearchParams.get("tags");
+  const languageIdsParam = getSearchParams.get("languageIds");
+  const ecosystemIdsParam = getSearchParams.get("ecosystemIds");
+  const categoryIdsParam = getSearchParams.get("categoryIds");
+  const searchParam = getSearchParams.get("search");
+
+  if (!sortByParam && !tagsParam && !languageIdsParam && !ecosystemIdsParam && !categoryIdsParam && !searchParam) {
+    return DEFAULT_FILTER;
+  }
+
+  return {
+    sortBy: sortByParam ?? undefined,
+    tags: tagsParam ? (tagsParam.split(",") as ProjectTag[]) : [],
+    languageIds: languageIdsParam ? languageIdsParam.split(",") : [],
+    ecosystemIds: ecosystemIdsParam ? ecosystemIdsParam.split(",") : [],
+    categoryIds: categoryIdsParam ? categoryIdsParam.split(",") : [],
+    search: searchParam ?? undefined,
+  };
+}
+
 export function BrowseProjectsContextProvider({ children }: BrowseProjectsContextProviderProps) {
   const { updateMultipleSearchParams, searchParams: getSearchParams } = useUpdateMultipleSearchParams();
-  const { deleteSearchParams } = useDeleteSearchParams();
-  const [filters, setFilters] = useState<BrowseProjectsContextFilter>(DEFAULT_FILTER);
+  const [filters, setFilters] = useState<BrowseProjectsContextFilter>(getFilterFromSearchParams(getSearchParams));
   const [queryParams, setQueryParams] = useState<BrowseProjectsContextQueryParams>({});
   const [debouncedQueryParams, setDebouncedQueryParams] = useState<BrowseProjectsContextQueryParams>(queryParams);
 
   useEffect(() => {
     const sortByParam = getSearchParams.get("sortBy");
     const tagsParam = getSearchParams.get("tags");
+    const languageIdsParam = getSearchParams.get("languageIds");
+    const ecosystemIdsParam = getSearchParams.get("ecosystemIds");
+    const categoryIdsParam = getSearchParams.get("categoryIds");
+    const searchParam = getSearchParams.get("search");
 
     setFilter({
       sortBy: sortByParam ?? undefined,
       tags: tagsParam ? (tagsParam.split(",") as ProjectTag[]) : [],
+      languageIds: languageIdsParam ? languageIdsParam.split(",") : [],
+      ecosystemIds: ecosystemIdsParam ? ecosystemIdsParam.split(",") : [],
+      categoryIds: categoryIdsParam ? categoryIdsParam.split(",") : [],
+      search: searchParam ?? undefined,
     });
   }, [getSearchParams]);
 
@@ -88,7 +116,9 @@ export function BrowseProjectsContextProvider({ children }: BrowseProjectsContex
       ...(debouncedQueryParams.search && { search: debouncedQueryParams.search }),
     };
 
-    updateMultipleSearchParams(queryParamsToSave);
+    if (Object.keys(queryParamsToSave).length > 0) {
+      updateMultipleSearchParams(queryParamsToSave);
+    }
   }, [debouncedQueryParams]);
 
   return (

--- a/app/(saas)/projects/_features/browse-projects-filters/browse-projects-filters.context.tsx
+++ b/app/(saas)/projects/_features/browse-projects-filters/browse-projects-filters.context.tsx
@@ -4,7 +4,7 @@ import { useDebounce } from "react-use";
 import { ProjectTag } from "@/core/domain/project/project.types";
 
 import { useDeleteSearchParams } from "@/shared/hooks/router/use-delete-search-params";
-import { useUpdateMultipleSearchParams, useUpdateSearchParams } from "@/shared/hooks/router/use-update-search-params";
+import { useUpdateMultipleSearchParams } from "@/shared/hooks/router/use-update-search-params";
 
 import {
   BrowseProjectsContextFilter,
@@ -79,15 +79,16 @@ export function BrowseProjectsContextProvider({ children }: BrowseProjectsContex
   }
 
   useEffect(() => {
-    const queryParamsToSave: Record<string, string> = {};
+    const queryParamsToSave: Record<string, string> = {
+      ...(debouncedQueryParams.tags && { tags: debouncedQueryParams.tags.join(",") }),
+      ...(debouncedQueryParams.languageIds && { languageIds: debouncedQueryParams.languageIds.join(",") }),
+      ...(debouncedQueryParams.ecosystemIds && { ecosystemIds: debouncedQueryParams.ecosystemIds.join(",") }),
+      ...(debouncedQueryParams.categoryIds && { categoryIds: debouncedQueryParams.categoryIds.join(",") }),
+      ...(debouncedQueryParams.sortBy && { sortBy: debouncedQueryParams.sortBy }),
+      ...(debouncedQueryParams.search && { search: debouncedQueryParams.search }),
+    };
 
-    Object.entries(debouncedQueryParams).forEach(([key, value]) => {
-      if (value) {
-        queryParamsToSave[key] = value;
-      }
-    });
-
-    updateMultipleSearchParams(queryParamsToSave.join("&"));
+    updateMultipleSearchParams(queryParamsToSave);
   }, [debouncedQueryParams]);
 
   return (

--- a/app/(saas)/projects/_features/browse-projects-filters/browse-projects-filters.types.ts
+++ b/app/(saas)/projects/_features/browse-projects-filters/browse-projects-filters.types.ts
@@ -35,4 +35,7 @@ export type BrowseProjectsContextReturn = {
 
 export interface BrowseProjectsContextProviderProps extends PropsWithChildren {}
 
-export type BrowseProjectsContextQueryParams = Omit<GetProjectsV2PortParams["queryParams"], "pageIndex" | "pageSize">;
+export type BrowseProjectsContextQueryParams = Omit<
+  NonNullable<GetProjectsV2PortParams["queryParams"]>,
+  "pageIndex" | "pageSize"
+>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced project browsing filters now persist your selections (sort, tags, languages, etc.) via the URL for a more seamless navigation experience.

- **Refactor**
  - Improved the underlying handling and synchronization of filter parameters to ensure your chosen settings are accurately maintained while you explore projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->