### PR TITLE
sb-41-dropdown-closes-when-scrolling-filters-in-admin-back-office

### DIFF
--- a/design-system/molecules/table-column-list/adapters/default/default.adapter.tsx
+++ b/design-system/molecules/table-column-list/adapters/default/default.adapter.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { Columns2, Search } from "lucide-react";
-import { X } from "lucide-react";
+import { Columns2, Search, X } from "lucide-react";
 import { ChangeEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -75,7 +74,7 @@ export function TableColumnListDefaultAdapter({
               onChange={handleSearch}
             />
 
-            <Menu {...menuProps} items={menuItems} classNames={{ content: "max-h-none" }} />
+            <Menu {...menuProps} items={menuItems} classNames={{ content: "max-h-[50vh]" }} />
           </div>
         )}
       </Popover.Content>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted the dropdown menu layout so that its content now remains within 50% of the viewport height, improving overall visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->