### PR TITLE
Restore header with login

### DIFF
--- a/app/(saas)/layout.tsx
+++ b/app/(saas)/layout.tsx
@@ -7,21 +7,17 @@ import "remixicon/fonts/remixicon.css";
 
 import { SaasProviders } from "@/app/(saas)/saas-providers";
 
+import { AppMigrationBanner } from "@/shared/features/app-migration-banner/app-migration-banner";
 import { AppHeader } from "@/shared/features/app/app-header/app-header";
-import { AppSidebar } from "@/shared/features/app/app-sidebar/app-sidebar";
-import { ImpersonationBanner } from "@/shared/features/impersonation/impersonation-banner";
-import { IndexingBanner } from "@/shared/features/indexing/indexing-banner";
 import { SidebarInset } from "@/shared/ui/sidebar";
 
 export default function SaasLayout({ children }: PropsWithChildren) {
   return (
     <SaasProviders>
-      <AppSidebar />
       <SidebarInset>
         <AppHeader />
+        <AppMigrationBanner />
         {children}
-        <ImpersonationBanner />
-        <IndexingBanner />
       </SidebarInset>
     </SaasProviders>
   );

--- a/app/(saas)/my-dashboard/layout.tsx
+++ b/app/(saas)/my-dashboard/layout.tsx
@@ -1,114 +1,29 @@
 "use client";
 
-import { PropsWithChildren, useCallback, useMemo } from "react";
+import { PropsWithChildren } from "react";
 
 import { RequestPayment } from "@/app/(saas)/my-dashboard/_features/request-payment/request-payment";
 
-import { Button } from "@/design-system/atoms/button/variants/button-default";
-import { Tabs } from "@/design-system/molecules/tabs/tabs";
-
-import { BaseLink } from "@/shared/components/base-link/base-link";
 import { withClientOnly } from "@/shared/components/client-only/client-only";
-import { NEXT_ROUTER } from "@/shared/constants/router";
 import { GithubPermissionsProvider } from "@/shared/features/github-permissions/github-permissions.context";
 import { PageContent } from "@/shared/features/page-content/page-content";
 import { PageContainer } from "@/shared/features/page/page-container/page-container";
-import { useMatchPath } from "@/shared/hooks/router/use-match-path";
 import { RequestPaymentFlowProvider } from "@/shared/panels/_flows/request-payment-flow/request-payment-flow.context";
 import { ContributionsSidepanel } from "@/shared/panels/contribution-sidepanel/contributions-sidepanel";
 import { ContributorSidepanel } from "@/shared/panels/contributor-sidepanel/contributor-sidepanel";
 import { useMyRewardsTransactionsSidepanel } from "@/shared/panels/my-rewards-transactions-sidepanel/my-rewards-transactions-sidepanel.hooks";
 import { withAuthenticated } from "@/shared/providers/auth-provider";
 import { PosthogCaptureOnMount } from "@/shared/tracking/posthog/posthog-capture-on-mount/posthog-capture-on-mount";
-import { Translate } from "@/shared/translation/components/translate/translate";
-
-enum Views {
-  "CONTRIBUTIONS" = "CONTRIBUTIONS",
-  "PROJECTS" = "PROJECTS",
-  "REWARDS" = "REWARDS",
-}
 
 function Safe({ children }: PropsWithChildren) {
-  const isContributions = useMatchPath(NEXT_ROUTER.myDashboard.contributions.root);
-  const isProjects = useMatchPath(NEXT_ROUTER.myDashboard.projects.root);
-  const isRewards = useMatchPath(NEXT_ROUTER.myDashboard.rewards.root);
-
-  const selectedId = useMemo(() => {
-    if (isContributions) {
-      return Views.CONTRIBUTIONS;
-    }
-
-    if (isProjects) {
-      return Views.PROJECTS;
-    }
-
-    if (isRewards) {
-      return Views.REWARDS;
-    }
-  }, [isContributions, isProjects, isRewards]);
-
-  const { open: openMyRewardsTransactions } = useMyRewardsTransactionsSidepanel();
-
-  const renderActions = useCallback(() => {
-    return (
-      <div className="flex items-center gap-lg">
-        {isRewards ? (
-          <Button
-            variant="secondary"
-            size="sm"
-            translate={{ token: "myDashboard:detail.actions.seeTransactions" }}
-            onClick={openMyRewardsTransactions}
-            classNames={{
-              base: "max-w-full overflow-hidden",
-              label: "whitespace-nowrap text-ellipsis overflow-hidden",
-            }}
-          />
-        ) : null}
-
-        <RequestPayment />
-      </div>
-    );
-  }, [isRewards]);
+  useMyRewardsTransactionsSidepanel();
 
   return (
     <PageContent>
       <div className="flex h-full flex-col gap-lg">
-        <header className="flex flex-col flex-wrap items-start justify-between gap-md tablet:flex-row tablet:items-center">
-          <Tabs
-            variant={"solid"}
-            searchParams={"data-view"}
-            tabs={[
-              {
-                id: Views.CONTRIBUTIONS,
-                children: <Translate token={"myDashboard:detail.views.contributions"} />,
-                as: BaseLink,
-                htmlProps: {
-                  href: NEXT_ROUTER.myDashboard.contributions.root,
-                },
-              },
-              {
-                id: Views.PROJECTS,
-                children: <Translate token={"myDashboard:detail.views.projects"} />,
-                as: BaseLink,
-                htmlProps: {
-                  href: NEXT_ROUTER.myDashboard.projects.root,
-                },
-              },
-              {
-                id: Views.REWARDS,
-                children: <Translate token={"myDashboard:detail.views.rewards"} />,
-                as: BaseLink,
-                htmlProps: {
-                  href: NEXT_ROUTER.myDashboard.rewards.root,
-                },
-              },
-            ]}
-            selectedId={selectedId}
-          />
-
-          <div className="flex items-center gap-lg">{renderActions()}</div>
-        </header>
-
+        <div className="self-end">
+          <RequestPayment />
+        </div>
         {children}
       </div>
     </PageContent>

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,7 +8,7 @@ const nextConfig = {
       // HOME
       {
         source: "/",
-        destination: "/discover",
+        destination: "/my-dashboard/rewards",
         permanent: true,
       },
       // DATA
@@ -32,7 +32,7 @@ const nextConfig = {
       // MY DASHBOARD
       {
         source: "/my-dashboard",
-        destination: "/my-dashboard/contributions",
+        destination: "/my-dashboard/rewards",
         permanent: true,
       },
       // PROJECTS

--- a/shared/features/app-migration-banner/app-migration-banner.tsx
+++ b/shared/features/app-migration-banner/app-migration-banner.tsx
@@ -1,0 +1,22 @@
+import { Alert } from "@/design-system/molecules/alert";
+import { BaseLink } from "@/shared/components/base-link/base-link";
+
+export function AppMigrationBanner() {
+  return (
+    <div className="m-4">
+      <Alert
+        color="brand"
+        title="The contributor app has moved"
+        description={
+          <span>
+            Please visit{' '}
+            <BaseLink href="https://contribute.onlydust.com">
+              contribute.onlydust.com
+            </BaseLink>{' '}
+            to access the new experience. This version only allows reward withdrawal.
+          </span>
+        }
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- show `AppHeader` in SaaS layout so login button is available

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*